### PR TITLE
feat: add info switch functionality

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.chouten.app"
         minSdk = 23
         targetSdk = 34
-        versionCode = 6
-        versionName = "0.0.6"
+        versionCode = 7
+        versionName = "0.1.0"
         buildConfigField("String", "WEBHOOK_URL", "\"${properties.getProperty("bug_webhook")}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/chouten/app/data/repository/WebviewHandlerImpl.kt
+++ b/app/src/main/java/com/chouten/app/data/repository/WebviewHandlerImpl.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.chouten.app.BuildConfig
 import com.chouten.app.R
 import com.chouten.app.domain.model.Payloads_V2.Action_V2
 import com.chouten.app.domain.repository.WebviewHandler
@@ -57,7 +58,7 @@ class WebviewHandlerImpl<BaseResultPayload : WebviewHandler.Companion.ActionPayl
             webview.settings.javaScriptEnabled = true
             webview.settings.domStorageEnabled = true
             webview.addJavascriptInterface(this, "Native")
-            WebView.setWebContentsDebuggingEnabled(true)
+            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
         }
         if (!::commonCode.isInitialized) {
             commonCode = getCommonCode(context)

--- a/app/src/main/java/com/chouten/app/di/WebviewModuleV2.kt
+++ b/app/src/main/java/com/chouten/app/di/WebviewModuleV2.kt
@@ -4,6 +4,7 @@ import com.chouten.app.data.repository.WebviewHandlerImpl
 import com.chouten.app.domain.model.Payloads_V2
 import com.chouten.app.domain.repository.WebviewHandler
 import com.chouten.app.presentation.ui.screens.info.InfoResult
+import com.chouten.app.presentation.ui.screens.info.SwitchConfig
 import com.chouten.app.presentation.ui.screens.search.SearchResult
 import com.chouten.app.presentation.ui.screens.watch.WatchResult
 import com.lagradost.nicehttp.Requests
@@ -25,6 +26,19 @@ object WebviewModuleV2 {
     fun provideSearchWebviewHandler(client: Requests): WebviewHandler<Payloads_V2.Action_V2, Payloads_V2.GenericPayload<List<SearchResult>>> {
         return WebviewHandlerImpl(client) { action, result: String ->
             Payloads_V2.GenericPayload(action, Json.decodeFromString(result))
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Provides
+    fun provideSwitchConfigWebviewHandler(client: Requests): WebviewHandler<Payloads_V2.Action_V2, Payloads_V2.GenericPayload<SwitchConfig>> {
+        val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            explicitNulls = false
+        }
+        return WebviewHandlerImpl(client) { action, result: String ->
+            Payloads_V2.GenericPayload(action, json.decodeFromString(result))
         }
     }
 

--- a/app/src/main/java/com/chouten/app/domain/model/Payloads_V2.kt
+++ b/app/src/main/java/com/chouten/app/domain/model/Payloads_V2.kt
@@ -32,6 +32,9 @@ object Payloads_V2 {
         @SerialName("info")
         GET_INFO,
 
+        @SerialName("switchConfig")
+        GET_SWITCH_CONFIG,
+
         @SerialName("metadata")
         GET_METADATA,
 

--- a/app/src/main/java/com/chouten/app/domain/repository/WebviewHandler.kt
+++ b/app/src/main/java/com/chouten/app/domain/repository/WebviewHandler.kt
@@ -73,6 +73,9 @@ interface WebviewHandler<Action : Enum<Action>, ResultPayload : WebviewHandler.C
      */
     suspend fun getCommonCode(context: Context): String
 
+    fun <T> getGenericValue(key: String): T?
+    fun <T> setGenericValue(key: String, value: T)
+
     companion object {
 
         /**

--- a/app/src/main/java/com/chouten/app/presentation/ui/screens/info/InfoViewModel.kt
+++ b/app/src/main/java/com/chouten/app/presentation/ui/screens/info/InfoViewModel.kt
@@ -78,6 +78,30 @@ data class InfoResult(
     ) : Parcelable
 }
 
+/**
+ * @param options The (2) options to be displayed in the switch
+ * @param default The index of the default option (0 or 1)
+ * @param cache Whether or not the webview should cache the result
+ * @param includeInfo Whether or not the webview should redo the info request
+ */
+@Serializable
+data class SwitchConfig(
+    val options: Array<String>, val default: Int, val cache: Boolean, val includeInfo: Boolean
+) {
+    companion object {
+        /**
+         * Whether or not the switch is toggled
+         * If the default is 1 and the toggle is "on", the switch is NOT toggled.
+         * If the default is 0 and the toggle is "off", the switch is NOT toggled.
+         * @param value The value of the switch
+         * @param config The config of the switch
+         * @return Whether or not the switch is toggled from it's default state
+         */
+        fun isToggled(value: Boolean, config: SwitchConfig): Boolean {
+            return value.xor((config.default == 0))
+        }
+    }
+}
 
 @HiltViewModel
 class InfoViewModel @Inject constructor(

--- a/app/src/main/res/raw/commoncode_v2.js
+++ b/app/src/main/res/raw/commoncode_v2.js
@@ -17,7 +17,13 @@ window.onmessage = async function (event) {
                 await getEpList(payload);
             }else if(payload.action === "video"){
                 await getSource(payload);
-            }else{
+            } else if (payload.action == "switchConfig") {
+                let config = getSwitchConfig()
+                Native.sendResult(JSON.stringify({
+                    action: "switchConfig",
+                    result: config
+                }))
+            } else{
                 await logic(payload);
             }
         }catch(err){
@@ -63,6 +69,10 @@ function sendSignal(signal, message = ""){
         action: signal === 0 ? "exit" : "error",
         result: message
     }));
+}
+
+function getSwitchValue() {
+    return Native.getSwitchValue();
 }
 
 function loadScript(url){


### PR DESCRIPTION
Allow modules to provide a way to switch between modes within the info page.
This is done using the following interface
```ts
interface SwitchConfig {
    // E.g ["Dub", "Sub"]
    options: [string, string];
    // E.g 0 ("Dub")
    default: number;
    // E.g True to not request the same URL twice (does not hold true across seasons)
    cache: boolean;
    // E.g True to re-request the Info page as well
    includeInfo: boolean;
}
```
The module must then implement a `getSwitchConfig` function which returns this `SwitchConfig`.
Within the module, the value of the switch can be retrieved via `getSwitchValue`.
For example, to get the label for the active option, you would do:
```ts
const appSwitch = switchConfig.options[getSwitchValue()];
// switch is 0 -> appSwitch = "Dub"
// switch is 1 -> appSwitch = "Sub"
```